### PR TITLE
Fix devstudio-tooling-ei#127

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <module>plugins</module>
         <module>features</module>
         <module>repository</module>
-        <!--module>installed-distribution</module-->
+        <module>installed-distribution</module>
     </modules>
     <scm>
         <connection>scm:git:https://github.com/wso2/developer-studio.git</connection>


### PR DESCRIPTION
Enable distribution installation at 1.2.0-release branch, so that OS specific distributions will be available at the weekly release.

## Purpose
Enable distribution installation for https://github.com/wso2/devstudio-tooling-ei/issues/127 
