### PR TITLE
[EI Tooling] Pack micro integrator into tooling runtime 

### DIFF
--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-linux-gtk-x86_64/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-linux-gtk-x86_64/pom.xml
@@ -106,6 +106,26 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <!--Unpack micro integrator extracted profile. This is installed by installer-script-oxygen.sh-->
+                    <execution>
+                        <id>unpack-micro integrator</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2</groupId>
+                                    <artifactId>micro-integrator</artifactId>
+                                    <version>6.4.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/eclipse/runtime</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution> 
                 </executions>
             </plugin>
 			<plugin>

--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-linux-gtk/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-linux-gtk/pom.xml
@@ -106,6 +106,26 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <!--Unpack micro integrator extracted profile. This is installed by installer-script-oxygen.sh-->
+                    <execution>
+                        <id>unpack-micro integrator</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2</groupId>
+                                    <artifactId>micro-integrator</artifactId>
+                                    <version>6.4.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/eclipse/runtime</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution> 
                 </executions>
             </plugin>
 			<plugin>

--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-macosx-cocoa-x86_64/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-macosx-cocoa-x86_64/pom.xml
@@ -105,7 +105,27 @@
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
-                    </execution>
+                    </execution> 
+                    <!--Unpack micro integrator extracted profile. This is installed by installer-script-oxygen.sh-->
+                    <execution>
+                        <id>unpack-micro integrator</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2</groupId>
+                                    <artifactId>micro-integrator</artifactId>
+                                    <version>6.4.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/Eclipse.app/Contents/Eclipse/runtime</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>   
                 </executions>
             </plugin>
 			<plugin>

--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-macosx-cocoa-x86_64/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-macosx-cocoa-x86_64/pom.xml
@@ -121,7 +121,7 @@
                                     <version>6.4.0</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>target/Eclipse.app/Contents/Eclipse/runtime</outputDirectory>
+                                    <outputDirectory>target/Eclipse.app/Contents/MacOS/runtime</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-win32/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-win32/pom.xml
@@ -106,6 +106,26 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <!--Unpack micro integrator extracted profile. This is installed by installer-script-oxygen.sh-->
+                    <execution>
+                        <id>unpack-micro integrator</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2</groupId>
+                                    <artifactId>micro-integrator</artifactId>
+                                    <version>6.4.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/eclipse/runtime</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution> 
                 </executions>
             </plugin>
 			<plugin>

--- a/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-win64-x86_64/pom.xml
+++ b/installed-distribution/developer-studio-ei-eclipse-jee-oxygen-win64-x86_64/pom.xml
@@ -106,6 +106,26 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <!--Unpack micro integrator extracted profile. This is installed by installer-script-oxygen.sh-->
+                    <execution>
+                        <id>unpack-micro integrator</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2</groupId>
+                                    <artifactId>micro-integrator</artifactId>
+                                    <version>6.4.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/eclipse/runtime</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution> 
                 </executions>
             </plugin>
 			<plugin>

--- a/installed-distribution/scripts/installer-script-oxygen.sh
+++ b/installed-distribution/scripts/installer-script-oxygen.sh
@@ -66,3 +66,4 @@ mvn install:install-file \
 
 rm -rf wso2ei-$PRODUCT_VERSION
 rm -rf wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
+

--- a/installed-distribution/scripts/installer-script-oxygen.sh
+++ b/installed-distribution/scripts/installer-script-oxygen.sh
@@ -63,7 +63,6 @@ mvn install:install-file \
   -Dfile=wso2ei-${PRODUCT_VERSION}_micro-integrator.zip \
   -DgeneratePom=true\
   -DlocalRepositoryPath=$1
-  
+
 rm -rf wso2ei-$PRODUCT_VERSION
 rm -rf wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
-  

--- a/installed-distribution/scripts/installer-script-oxygen.sh
+++ b/installed-distribution/scripts/installer-script-oxygen.sh
@@ -64,3 +64,6 @@ mvn install:install-file \
   -DgeneratePom=true\
   -DlocalRepositoryPath=$1
   
+rm -rf wso2ei-$PRODUCT_VERSION
+rm -rf wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
+  

--- a/installed-distribution/scripts/installer-script-oxygen.sh
+++ b/installed-distribution/scripts/installer-script-oxygen.sh
@@ -1,8 +1,14 @@
+#! /bin/bash
+
+PRODUCT_VERSION=6.4.0
+
 wget http://product-dist.wso2.com/p2/developer-studio-kernel/eclipse/oxygen3a/eclipse-jee-oxygen-3a-linux-gtk-x86_64.tar.gz
 wget http://product-dist.wso2.com/p2/developer-studio-kernel/eclipse/oxygen3a/eclipse-jee-oxygen-3a-linux-gtk.tar.gz
 wget http://product-dist.wso2.com/p2/developer-studio-kernel/eclipse/oxygen3a/eclipse-jee-oxygen-3a-macosx-cocoa-x86_64.tar.gz
 wget http://product-dist.wso2.com/p2/developer-studio-kernel/eclipse/oxygen3a/eclipse-jee-oxygen-3a-win32-x86_64.zip
 wget http://product-dist.wso2.com/p2/developer-studio-kernel/eclipse/oxygen3a/eclipse-jee-oxygen-3a-win32.zip
+wget http://atuwa.private.wso2.com/WSO2-Products/enterprise-integrator/6.4.0/wso2ei-6.4.0.zip
+
 mvn install:install-file \
   -DgroupId=org.eclipse \
   -DartifactId=eclipse-jee-oxygen-3a-linux-gtk-x86_64 \
@@ -42,4 +48,19 @@ mvn install:install-file \
   -Dversion=4.7.3a \
   -Dfile=eclipse-jee-oxygen-3a-win32.zip \
   -DgeneratePom=true\
+  -DlocalRepositoryPath=$1  
+  
+#generate micro integrator profile
+unzip wso2ei-$PRODUCT_VERSION.zip
+#input 6 into profile-creator tool
+echo 6|./wso2ei-$PRODUCT_VERSION/bin/profile-creator.sh
+
+mvn install:install-file \
+  -DgroupId=org.wso2 \
+  -DartifactId=micro-integrator \
+  -Dpackaging=zip \
+  -Dversion=$PRODUCT_VERSION \
+  -Dfile=wso2ei-${PRODUCT_VERSION}_micro-integrator.zip \
+  -DgeneratePom=true\
   -DlocalRepositoryPath=$1
+  

--- a/plugins/org.wso2.developerstudio.eclipse.ei.project/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.ei.project/plugin.xml
@@ -26,6 +26,10 @@
             carbon.server.version="carbon.server.44ei"
             server.display.name="WSO2 Enterprise Integrator 6.5.0">
       </product.server>
+       <product.server
+               carbon.server.version="carbon.server.44microei"
+               server.display.name="WSO2 Enterprise Micro Integrator">
+       </product.server>
     </extension>
     <extension-point id="org.wso2.developerstudio.aboutDialog.contributor" name="AboutDialogContributor" schema="schema/org.wso2.developerstudio.aboutDialog.contributor.exsd"/>
     <extension point="org.eclipse.ui.menus">

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <version.sortpom.plugin>2.3.0</version.sortpom.plugin>
         <webeditor.version>4.0.0-SNAPSHOT</webeditor.version>
         <wso2.tomcat.version>7.0.59.wso2v3</wso2.tomcat.version>
+        <ei.product.version>6.4.0</ei.product.version>
     </properties>
     <repositories>
         <repository>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
@@ -41,37 +41,25 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>
+            <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <version>1.3.0</version>
                 <executions>
                     <execution>
-                        <id>download-xulrunner-64</id>
+                        <id>download-micro-esb</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://builder1.us1.wso2.org/~developerstudio/developer-studio-kernel/dependencies/xulrunner/x86_64/xulrunner-24.0.en-US.win64.zip</url>
+                            <url>http://atuwa.private.wso2.com/WSO2-Products/enterprise-integrator/${ei.product.version}/wso2ei-${ei.product.version}.zip</url>
                             <unpack>true</unpack>
-                            <outputDirectory>${project.build.directory}/products/WSO2-Developer-Studio/win32/win32/x86_64</outputDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download-xulrunner-32</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>http://builder1.us1.wso2.org/~developerstudio/developer-studio-kernel/dependencies/xulrunner/x86/xulrunner-24.0.en-US.win32.zip</url>
-                            <unpack>true</unpack>
-                            <outputDirectory>${project.build.directory}/products/WSO2-Developer-Studio/win32/win32/x86</outputDirectory>
+                            <outputDirectory>${project.build.directory}/products</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -112,6 +100,23 @@
                             <descriptors>
                                 <descriptor>${basedir}/assembly/macosx.cocoa_x86_64.xml</descriptor>
                             </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution>
+                        <id>Download-Eclipse_distributions</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <commandlineArgs>${ei.product.version}</commandlineArgs>
+                            <executable>${project.basedir}/scripts/installer-script-oxygen.sh</executable>
                         </configuration>
                     </execution>
                 </executions>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
@@ -1,40 +1,73 @@
-mvn install:install-file \
-  -DgroupId=org.eclipse \
-  -DartifactId=eclipse-jee-oxygen-3a-linux-gtk-x86_64 \
-  -Dpackaging=zip \
-  -Dversion=4.7.3a \
-  -Dfile=target/products/WSO2-Developer-Studio-linux-gtk-x86_64.zip \
-  -DgeneratePom=true\
-  -DlocalRepositoryPath=$1
-mvn install:install-file \
-  -DgroupId=org.eclipse \
-  -DartifactId=eclipse-jee-oxygen-3a-linux-gtk \
-  -Dpackaging=zip \
-  -Dversion=4.7.3a \
-  -Dfile=target/products/WSO2-Developer-Studio-linux-gtk-x86.zip \
-  -DgeneratePom=true\
-  -DlocalRepositoryPath=$1
-mvn install:install-file \
-  -DgroupId=org.eclipse \
-  -DartifactId=eclipse-jee-oxygen-3a-macosx-cocoa-x86_64 \
-  -Dpackaging=zip \
-  -Dversion=4.7.3a \
-  -Dfile=target/products/WSO2-Developer-Studio-macosx-cocoa-x86_64.zip \
-  -DgeneratePom=true\
-  -DlocalRepositoryPath=$1
-mvn install:install-file \
-  -DgroupId=org.eclipse \
-  -DartifactId=eclipse-jee-oxygen-3a-win64-x86_64 \
-  -Dpackaging=zip \
-  -Dversion=4.7.3a \
-  -Dfile=target/products/WSO2-Developer-Studio-win32-x86_64.zip \
-  -DgeneratePom=true\
-  -DlocalRepositoryPath=$1
-mvn install:install-file \
-  -DgroupId=org.eclipse \
-  -DartifactId=eclipse-jee-oxygen-3a-win32 \
-  -Dpackaging=zip \
-  -Dversion=4.7.3a \
-  -Dfile=target/products/WSO2-Developer-Studio-win32-x86.zip \
-  -DgeneratePom=true\
-  -DlocalRepositoryPath=$1
+#! /bin/bash
+BASE_DIR=$(pwd)
+PRODUCT_VERSION=$1
+
+echo BASE_DIR $BASE_DIR and PRODUCT_VERSION $PRODUCT_VERSION
+
+PRODUCTS_PATH=$BASE_DIR/target/products/WSO2-Developer-Studio
+
+#Generate micro esb profile. Input 6 into profile-creator tool
+echo 6|$BASE_DIR/target/products/wso2ei-$PRODUCT_VERSION/bin/profile-creator.sh
+
+#Create temp directory and unzip created packages
+mkdir $BASE_DIR/target/products/temp
+mkdir $BASE_DIR/target/products/temp/linux-x86
+mkdir $BASE_DIR/target/products/temp/linux-x86_64
+mkdir $BASE_DIR/target/products/temp/macos
+mkdir $BASE_DIR/target/products/temp/win-x86
+mkdir $BASE_DIR/target/products/temp/win-x86_64
+
+
+unzip $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip -d $BASE_DIR/target/products/temp/linux-x86
+unzip $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip -d $BASE_DIR/target/products/temp/linux-x86_64
+unzip $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip -d $BASE_DIR/target/products/temp/macos
+unzip $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip -d $BASE_DIR/target/products/temp/win-x86
+unzip $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip -d $BASE_DIR/target/products/temp/win-x86_64
+
+
+
+
+#Unzip micro esb to relevant packages
+unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/linux-x86/runtime
+unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/linux-x86_64/runtime
+unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime
+unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/win-x86/runtime
+unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/win-x86_64/runtime
+
+#rename as "microesb" (this is the static name used in EI Tooling code)
+mv $BASE_DIR/target/products/temp/linux-x86/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/linux-x86/runtime/microesb
+mv $BASE_DIR/target/products/temp/linux-x86_64/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/linux-x86_64/runtime/microesb
+mv $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime/microesb
+mv $BASE_DIR/target/products/temp/win-x86/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/win-x86/runtime/microesb
+mv $BASE_DIR/target/products/temp/win-x86_64/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/win-x86_64/runtime/microesb
+
+
+#clean up existing packages
+rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip
+rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip
+rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip
+rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip
+rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
+
+
+#Zip the packages with microesb
+
+current_dir=$(pwd)
+
+cd $BASE_DIR/target/products/temp/linux-x86
+zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip *
+cd $BASE_DIR/target/products/temp/linux-x86_64
+zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip *
+cd $BASE_DIR/target/products/temp/macos
+zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip *
+cd $BASE_DIR/target/products/temp/win-x86
+zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip *
+cd $BASE_DIR/target/products/temp/win-x86_64
+zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip *
+
+cd $current_dir
+
+#cleanup
+rm -rf $BASE_DIR/target/products/wso2ei-$PRODUCT_VERSION
+rm -rf $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
+rm -rf $BASE_DIR/target/products/temp

--- a/repository/composite/category.xml
+++ b/repository/composite/category.xml
@@ -37,6 +37,9 @@
  <feature id="org.wso2.developerstudio.carbon.server-44ei.feature" version="0.0.0">
       <category name="org.wso2.developerstudio.eclipse.ei.feature.category"/>
    </feature>
+ <feature id="org.wso2.developerstudio.carbon.server-44microei.feature" version="0.0.0">
+      <category name="org.wso2.developerstudio.kernel.platform.bundles"/>
+   </feature>
  <feature id="org.wso2.developerstudio.dashboard.feature" version="0.0.0">
       <category name="org.wso2.developerstudio.eclipse.ei.feature.category"/>
    </feature>


### PR DESCRIPTION
## Purpose

Resolve issue https://github.com/wso2/product-ei/issues/2739

## Goals

On build time package micro integrator into tooling pack 

## Approach

1. wget EI server
2. Run profile creator script and create micro integrator profile as a zip
3. Un-package it to a folder called "runtime" in eclipse EI tooling package 

## User stories

Integrate micro integrator into tooling so that user can try out developed artifacts without leaving the tool.

## Release note

N/A

## Documentation

N/A

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

https://github.com/wso2/devstudio-tooling-platform/pull/116

## Migrations (if applicable)

N/A

## Test environment

Tested on Mac High Sierra
 
## Learning

N/A