### PR TITLE
Embed OpenJDK into the RCP Pack

### DIFF
--- a/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
@@ -61,6 +61,49 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <id>download-jdk-linux</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>http://product-dist.wso2.com/tools/developerstudio/jdk-distributions/OpenJDK8U-jdk_x64_linux_hotspot_8u192b12.tar.gz</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/jdk/jdk-linux</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-jdk-windows</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>http://product-dist.wso2.com/tools/developerstudio/jdk-distributions/OpenJDK8U-jdk_x64_windows_hotspot_8u192b12.zip</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/jdk/jdk-windows</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-jdk-macos</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>http://product-dist.wso2.com/tools/developerstudio/jdk-distributions/OpenJDK8U-jdk_x64_mac_hotspot_8u192b12.tar.gz</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/jdk/jdk-macos</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <executions>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
@@ -4,70 +4,139 @@ PRODUCT_VERSION=$1
 
 echo BASE_DIR $BASE_DIR and PRODUCT_VERSION $PRODUCT_VERSION
 
-PRODUCTS_PATH=$BASE_DIR/target/products/WSO2-Developer-Studio
+# Product extraction locations
+PRODUCT_PATH_ROOT=$BASE_DIR/target/products
+PRODUCT_PATH_LINUX_86=$PRODUCT_PATH_ROOT/temp/linux-x86
+PRODUCT_PATH_LINUX_64=$PRODUCT_PATH_ROOT/temp/linux-x86_64
+PRODUCT_PATH_MACOS=$PRODUCT_PATH_ROOT/temp/macos
+PRODUCT_PATH_WIN_86=$PRODUCT_PATH_ROOT/temp/win-x86
+PRODUCT_PATH_WIN_64=$PRODUCT_PATH_ROOT/temp/win-x86_64
 
-#Generate micro esb profile. Input 6 into profile-creator tool
-echo 6|$BASE_DIR/target/products/wso2ei-$PRODUCT_VERSION/bin/profile-creator.sh
+# Temporary location of JDK distributions
+JDK_DISTRIBUTION_PATH=$BASE_DIR/target/jdk
+JDK_DEFAULT_DIRECTORY_NAME="jdk-home"
+JDK_DISTRIBUTION_FILE_PREFIX="OpenJDK"
+JDK_DIRECTORY_PREFIX="jdk8u"
+JDK_HOME_LINUX="$JDK_DEFAULT_DIRECTORY_NAME/bin"
+JDK_HOME_WINDOWS="$JDK_DEFAULT_DIRECTORY_NAME/bin"
+JDK_HOME_MACOS="..\/Eclipse/$JDK_DEFAULT_DIRECTORY_NAME/Contents/Home/bin"
+JDK_DISTRIBUTION_NAME="jdk-distibution"
+MACOS_ECLIPSE_CONFIG_PATH="$PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse"
+MACOS_JDK_LIB_PATH="$PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/$JDK_DEFAULT_DIRECTORY_NAME/Contents/Home/jre/lib"
 
-#Create temp directory and unzip created packages
-mkdir $BASE_DIR/target/products/temp
-mkdir $BASE_DIR/target/products/temp/linux-x86
-mkdir $BASE_DIR/target/products/temp/linux-x86_64
-mkdir $BASE_DIR/target/products/temp/macos
-mkdir $BASE_DIR/target/products/temp/win-x86
-mkdir $BASE_DIR/target/products/temp/win-x86_64
+JDK_DISTRIBUTION_PATH_LINUX=$JDK_DISTRIBUTION_PATH/jdk-linux
+JDK_DISTRIBUTION_PATH_WINDOWS=$JDK_DISTRIBUTION_PATH/jdk-windows
+JDK_DISTRIBUTION_PATH_MACOS=$JDK_DISTRIBUTION_PATH/jdk-macos
 
+# Generate micro esb profile. Input 6 into profile-creator tool
+echo 6|$PRODUCT_PATH_ROOT/wso2ei-$PRODUCT_VERSION/bin/profile-creator.sh
 
-unzip $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip -d $BASE_DIR/target/products/temp/linux-x86
-unzip $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip -d $BASE_DIR/target/products/temp/linux-x86_64
-unzip $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip -d $BASE_DIR/target/products/temp/macos
-unzip $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip -d $BASE_DIR/target/products/temp/win-x86
-unzip $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip -d $BASE_DIR/target/products/temp/win-x86_64
+# Create temp directory and unzip created packages
+mkdir $PRODUCT_PATH_ROOT/temp
+mkdir $PRODUCT_PATH_LINUX_86
+mkdir $PRODUCT_PATH_LINUX_64
+mkdir $PRODUCT_PATH_MACOS
+mkdir $PRODUCT_PATH_WIN_86
+mkdir $PRODUCT_PATH_WIN_64
 
+unzip $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip -d $PRODUCT_PATH_LINUX_86
+unzip $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip -d $PRODUCT_PATH_LINUX_64
+unzip $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip -d $PRODUCT_PATH_MACOS
+unzip $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86.zip -d $PRODUCT_PATH_WIN_86
+unzip $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86_64.zip -d $PRODUCT_PATH_WIN_64
 
+# Unzip micro esb to relevant packages
+unzip $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $PRODUCT_PATH_LINUX_86/runtime
+unzip $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $PRODUCT_PATH_LINUX_64/runtime
+unzip $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/MacOS/runtime
+unzip $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $PRODUCT_PATH_WIN_86/runtime
+unzip $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $PRODUCT_PATH_WIN_64/runtime
 
+# Rename as "microesb" (this is the static name used in EI Tooling code)
+mv $PRODUCT_PATH_LINUX_86/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_LINUX_86/runtime/microesb
+mv $PRODUCT_PATH_LINUX_64/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_LINUX_64/runtime/microesb
+mv $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/MacOS/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/MacOS/runtime/microesb
+mv $PRODUCT_PATH_WIN_86/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_WIN_86/runtime/microesb
+mv $PRODUCT_PATH_WIN_64/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_WIN_64/runtime/microesb
 
-#Unzip micro esb to relevant packages
-unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/linux-x86/runtime
-unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/linux-x86_64/runtime
-unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime
-unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/win-x86/runtime
-unzip $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip -d $BASE_DIR/target/products/temp/win-x86_64/runtime
+# Clean up existing packages
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
 
-#rename as "microesb" (this is the static name used in EI Tooling code)
-mv $BASE_DIR/target/products/temp/linux-x86/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/linux-x86/runtime/microesb
-mv $BASE_DIR/target/products/temp/linux-x86_64/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/linux-x86_64/runtime/microesb
-mv $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/macos/DeveloperStudio.app/Contents/MacOS/runtime/microesb
-mv $BASE_DIR/target/products/temp/win-x86/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/win-x86/runtime/microesb
-mv $BASE_DIR/target/products/temp/win-x86_64/runtime/wso2ei-$PRODUCT_VERSION $BASE_DIR/target/products/temp/win-x86_64/runtime/microesb
+# Extract JDK distributions
+pushd ${JDK_DISTRIBUTION_PATH_LINUX}
+mv $JDK_DISTRIBUTION_FILE_PREFIX* $JDK_DISTRIBUTION_NAME.tar.gz
+tar xzf $JDK_DISTRIBUTION_NAME.tar.gz -C $PRODUCT_PATH_LINUX_64
+popd
 
+pushd ${JDK_DISTRIBUTION_PATH_WINDOWS}
+mv $JDK_DISTRIBUTION_FILE_PREFIX* $JDK_DISTRIBUTION_NAME.zip
+unzip $JDK_DISTRIBUTION_NAME.zip -d $PRODUCT_PATH_WIN_64
+popd
 
-#clean up existing packages
-rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip
-rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip
-rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip
-rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip
-rm -rf $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
+pushd ${JDK_DISTRIBUTION_PATH_MACOS}
+mv $JDK_DISTRIBUTION_FILE_PREFIX* $JDK_DISTRIBUTION_NAME.tar.gz
+tar xzf $JDK_DISTRIBUTION_NAME.tar.gz -C $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse
+popd
 
+# Configure JDKs
+pushd ${PRODUCT_PATH_LINUX_64}
+mv $JDK_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
+sed -e '/-vmargs/i\'$'\n''-vm' developerstudio.ini > developerstudio_temp.ini
+sed -e '/-vmargs/i\'$'\n'$JDK_HOME_LINUX developerstudio_temp.ini > developerstudio.ini
+rm -f developerstudio_temp.ini
+popd
 
-#Zip the packages with microesb
+pushd ${PRODUCT_PATH_WIN_64}
+mv $JDK_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
+sed -e '/-vmargs/i\'$'\n''-vm' developerstudio.ini > developerstudio_temp.ini
+sed -e '/-vmargs/i\'$'\n'$JDK_HOME_WINDOWS developerstudio_temp.ini > developerstudio.ini
+rm -f developerstudio_temp.ini
+popd
 
-current_dir=$(pwd)
+pushd ${MACOS_ECLIPSE_CONFIG_PATH}
+mv $JDK_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
+sed -e '/-vmargs/i\'$'\n''-vm' developerstudio.ini > developerstudio_temp.ini
+sed -e '/-vmargs/i\'$'\n'$JDK_HOME_MACOS developerstudio_temp.ini > developerstudio.ini
+rm -f developerstudio_temp.ini
+popd
 
-cd $BASE_DIR/target/products/temp/linux-x86
-zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip *
-cd $BASE_DIR/target/products/temp/linux-x86_64
-zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip *
-cd $BASE_DIR/target/products/temp/macos
-zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip *
-cd $BASE_DIR/target/products/temp/win-x86
-zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86.zip *
-cd $BASE_DIR/target/products/temp/win-x86_64
-zip -r $BASE_DIR/target/products/WSO2-Developer-Studio-win32.win32.x86_64.zip *
+pushd ${MACOS_JDK_LIB_PATH}
+cp libfreetype.dylib.6 libfreetype.6.dylib
+popd
 
-cd $current_dir
+# Zip the packages with microesb and JDK
+pushd ${PRODUCT_PATH_LINUX_86}
+zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip *
+popd
 
-#cleanup
-rm -rf $BASE_DIR/target/products/wso2ei-$PRODUCT_VERSION
-rm -rf $BASE_DIR/target/products/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
-rm -rf $BASE_DIR/target/products/temp
+pushd ${PRODUCT_PATH_LINUX_64}
+zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip *
+popd
+
+pushd ${PRODUCT_PATH_MACOS}
+# The reason for using ditto on BSD kernels is to preserve the package state of the JDK. Using the zip command will
+# result in losing the package state of the JDK packed inside
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    ditto -c -k --sequesterRsrc --keepParent * $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
+else
+    zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip *
+fi
+popd
+
+pushd ${PRODUCT_PATH_WIN_86}
+zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86.zip *
+popd
+
+pushd ${PRODUCT_PATH_WIN_64}
+zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86_64.zip *
+popd
+
+# Cleanup
+rm -rf $PRODUCT_PATH_ROOT/wso2ei-$PRODUCT_VERSION
+rm -rf $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
+rm -rf $PRODUCT_PATH_ROOT/temp
+rm -rf $JDK_DISTRIBUTION_PATH


### PR DESCRIPTION
Embedding OpenJDK (AdoptOpenJDK) 8 into the RCP Pack and configuring the Eclipse to pick the JDK from within.

We have chosen AdoptOpenJDK https://adoptopenjdk.net/ as they have distributions for multiple platforms including a ported version of OpenJDK 8 for MacOS. Platform-dependent JDK distributions are downloaded during the build time and extracted into each platform-dependent Tooling distributions. Eclipse has also been configured during the build time to utilise the embedded JDK.