### PR TITLE
Change RCP distribution compression type to tar.gz

### DIFF
--- a/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
@@ -178,16 +178,16 @@
                      <configuration>
                          <fileSets>
                                 <fileSet>
-                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.zip</sourceFile>
-                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux-gtk-x86_64.zip</destinationFile>
+                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux.gtk.x86_64.tar.gz</sourceFile>
+                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux-gtk-x86_64.tar.gz</destinationFile>
                                 </fileSet>
                                 <fileSet>
-                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux.gtk.x86.zip</sourceFile>
-                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux-gtk-x86.zip</destinationFile>
+                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux.gtk.x86.tar.gz</sourceFile>
+                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-linux-gtk-x86.tar.gz</destinationFile>
                                 </fileSet>
                                 <fileSet>
-                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip</sourceFile>
-                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-macosx-cocoa-x86_64.zip</destinationFile>
+                                    <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-macosx.cocoa.x86_64.tar.gz</sourceFile>
+                                    <destinationFile>${project.basedir}/target/products/WSO2-Developer-Studio-macosx-cocoa-x86_64.tar.gz</destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>${project.basedir}/target/products/WSO2-Developer-Studio-win32.win32.x86.zip</sourceFile>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
@@ -60,11 +60,11 @@ mv $PRODUCT_PATH_WIN_86/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_WIN_86/run
 mv $PRODUCT_PATH_WIN_64/runtime/wso2ei-$PRODUCT_VERSION $PRODUCT_PATH_WIN_64/runtime/microesb
 
 # Clean up existing packages
-rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip
-rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.tar.gz
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.tar.gz
 rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86.zip
 rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-win32.win32.x86_64.zip
-rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.tar.gz
 
 # Extract JDK distributions
 pushd ${JDK_DISTRIBUTION_PATH_LINUX}
@@ -110,21 +110,18 @@ popd
 
 # Zip the packages with microesb and JDK
 pushd ${PRODUCT_PATH_LINUX_86}
-zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip *
+tar -czf WSO2-Developer-Studio-linux.gtk.x86.tar.gz *
+mv WSO2-Developer-Studio-linux.gtk.x86.tar.gz $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.tar.gz
 popd
 
 pushd ${PRODUCT_PATH_LINUX_64}
-zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip *
+tar -czf WSO2-Developer-Studio-linux.gtk.x86_64.tar.gz *
+mv WSO2-Developer-Studio-linux.gtk.x86_64.tar.gz $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.tar.gz
 popd
 
 pushd ${PRODUCT_PATH_MACOS}
-# The reason for using ditto on BSD kernels is to preserve the package state of the JDK. Using the zip command will
-# result in losing the package state of the JDK packed inside
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ditto -c -k --sequesterRsrc --keepParent * $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip
-else
-    zip -r $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip *
-fi
+tar -czf WSO2-Developer-Studio-macosx.cocoa.x86_64.tar.gz *
+mv WSO2-Developer-Studio-macosx.cocoa.x86_64.tar.gz $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.tar.gz
 popd
 
 pushd ${PRODUCT_PATH_WIN_86}
@@ -140,3 +137,7 @@ rm -rf $PRODUCT_PATH_ROOT/wso2ei-$PRODUCT_VERSION
 rm -rf $PRODUCT_PATH_ROOT/wso2ei-${PRODUCT_VERSION}_micro-integrator.zip
 rm -rf $PRODUCT_PATH_ROOT/temp
 rm -rf $JDK_DISTRIBUTION_PATH
+
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-linux.gtk.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Developer-Studio-macosx.cocoa.x86_64.zip


### PR DESCRIPTION
## Purpose
Changing the RCP product distribution compression type to _tar.gz_ as the type _zip_ does not preserve the package state of the JDK for MacOS platforms.