### PR TITLE
Register new docker project type

### DIFF
--- a/rcp-product/org.wso2.developerstudio.rcp.product/developerstudio.product
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/developerstudio.product
@@ -367,6 +367,7 @@ Please visit : http://wso2.com/products/developer-studio/
       <feature id="org.wso2.developerstudio.eclipse.dss.dependencies.feature"/>
       <!-- Dev studio EI features -->
       <feature id="org.wso2.developerstudio.eclipse.ei.project.feature"/>
+      <feature id="org.wso2.developerstudio.eclipse.docker.distribution.feature"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
## Purpose
> Introducing a new project type to create docker images

## Goals
> Users should be able to use this docker project in their CICD pipelines. 

## Approach
> Introduced a new maven project type which selects the existing carbon application in the workspace as dependencies and creates an MI docker image from them. 