### PR TITLE
Packing Maven with Integration Studio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <webeditor.version>4.0.0-SNAPSHOT</webeditor.version>
         <wso2.tomcat.version>7.0.59.wso2v3</wso2.tomcat.version>
         <mi.product.version>1.1.0-beta3</mi.product.version>
+        <apache.maven.version>3.6.3</apache.maven.version>
     </properties>
     <repositories>
         <repository>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/pom.xml
@@ -66,6 +66,25 @@
                 <version>1.3.0</version>
                 <executions>
                     <execution>
+                        <id>download-latest-apache-maven</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://downloads.apache.org/maven/maven-3/${apache.maven.version}/binaries/apache-maven-${apache.maven.version}-bin.zip</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/products</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
                         <id>download-jdk-linux</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -158,7 +177,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <commandlineArgs>${mi.product.version}</commandlineArgs>
+                            <commandlineArgs>${mi.product.version} ${apache.maven.version}</commandlineArgs>
                             <executable>${project.basedir}/scripts/installer-script-oxygen.sh</executable>
                         </configuration>
                     </execution>

--- a/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
+++ b/rcp-product/org.wso2.developerstudio.rcp.product/scripts/installer-script-oxygen.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 BASE_DIR=$(pwd)
 PRODUCT_VERSION=$1
+APACHE_MAVEN_VERSION=$2
 
 echo BASE_DIR $BASE_DIR and PRODUCT_VERSION $PRODUCT_VERSION
 
@@ -66,6 +67,20 @@ mv $PRODUCT_PATH_LINUX_64/runtime/wso2mi-$PRODUCT_VERSION $PRODUCT_PATH_LINUX_64
 mv $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/runtime/wso2mi-$PRODUCT_VERSION $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/runtime/microesb
 mv $PRODUCT_PATH_WIN_86/runtime/wso2mi-$PRODUCT_VERSION $PRODUCT_PATH_WIN_86/runtime/microesb
 mv $PRODUCT_PATH_WIN_64/runtime/wso2mi-$PRODUCT_VERSION $PRODUCT_PATH_WIN_64/runtime/microesb
+
+# Unzip apche maven to relevant packages
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_LINUX_86/
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_LINUX_64/
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_WIN_86/
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_WIN_64/
+
+# Rename as "apche-maven" (this is the static name used in EI Tooling code)
+mv $PRODUCT_PATH_LINUX_86/apache-maven-$APACHE_MAVEN_VERSION $PRODUCT_PATH_LINUX_86/apache-maven
+mv $PRODUCT_PATH_LINUX_64/apache-maven-$APACHE_MAVEN_VERSION $PRODUCT_PATH_LINUX_64/apache-maven
+mv $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_MACOS/DeveloperStudio.app/Contents/Eclipse/apache-maven
+mv $PRODUCT_PATH_WIN_86/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_WIN_86/apache-maven
+mv $PRODUCT_PATH_WIN_64/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_WIN_64/apache-maven
 
 # Replace "deployment.toml" in Micro Integrator
 cp -f $DEPLOYMENT_FILE_PATH $PRODUCT_PATH_LINUX_86/runtime/microesb/conf
@@ -194,6 +209,7 @@ popd
 
 # Cleanup
 rm $PRODUCT_PATH_ROOT/wso2mi-$PRODUCT_VERSION.zip
+rm $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip
 rm -rf $PRODUCT_PATH_ROOT/temp
 rm -rf $PRODUCT_PATH_ROOT/IntegrationStudio
 rm -rf $JDK_DISTRIBUTION_PATH


### PR DESCRIPTION
Pack maven with the integration studio because the maven embedded in eclipse is an older version and it does not support the new version of spotify plugin.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/921